### PR TITLE
Fixed get line from failure after updated dependencies of TSlint

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ PathFormatter.prototype = Object.create({
 			var lineAndCharacter = failure.getStartPosition().getLineAndCharacter();
 			var item = {
 				reason: failure.getFailure(),
-				line: lineAndCharacter.line() + 1,
-				character: lineAndCharacter.character() + 1,
+                line: lineAndCharacter.line,
+                character: lineAndCharacter.character + 1,
 				code: (failure.getRuleName ? failure.getRuleName() : '')
 			};
 			res.errors.push(item);

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "grunt-cli": "0.1.9",
-    "grunt": "~0.4.1",
-    "grunt-tslint": "~0.4.0",
-    "grunt-contrib-jshint": "0.6.4",
-    "jshint-path-reporter": "0.1.3",
-    "grunt-run-grunt": "~0.1.0",
-    "grunt-mocha-test": "~0.7.0",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-continue": "0.0.1",
     "chai": "~1.8.1",
+    "grunt": "^0.4.5",
+    "grunt-cli": "0.1.9",
+    "grunt-continue": "0.0.1",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-jshint": "0.6.4",
+    "grunt-mocha-test": "~0.7.0",
+    "grunt-run-grunt": "~0.1.0",
+    "grunt-tslint": "~0.4.0",
+    "jshint-path-reporter": "0.1.3",
     "mocha-unfunk-reporter": "~0.4.0"
   }
 }


### PR DESCRIPTION
Fixed  '''lineAndCharacter.line isn't a function''' error after re-installing TSLint (I think one of its dependencies changed). 

Also, removed the "+ 1" increment of the line number as it produced the wrong line number (maybe also part of the dependencies change).

Tests don't pass but they didn't pass before this change either. I think TSLint's output has changed.
